### PR TITLE
Set version for maintenance releases and modify build to support use from docker image

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,24 +22,26 @@ build-py: setup.py $(wildcard bin/*) $(wildcard esitoolsupport/*)
 	@PYTHON@ setup.py build
 
 build/image/eucalyptus-service-image.raw: eucalyptus-service-image.ks
-	mkdir -p build/image
+	mkdir -m 777 -p build/image
 	$(destroyvm)
 	@PYTHON@ -c 'import pty, sys; pty.spawn(sys.argv[1:])' \
 		@VIRT_INSTALL@ --name $< \
 		--initrd-inject $< \
 		--extra-args ks="file:/$< console=tty0 console=ttyS0,115200 serial" \
 		--location @INSTALL_TREE@ \
+		--network=user \
 		--disk $@,format=raw,size=$(DISK) \
 		--vcpus $(CPUS) --ram $(MEMORY) \
+		--cpu=host \
 		--graphics none \
-		--hvm --accelerate --noreboot \
+		--hvm --virt-type=kvm --noreboot \
 		; STATUS=$$?; $(destroyvm); exit $$STATUS
 	@VIRT_SYSPREP@ -a $@
 	@VIRT_SPARSIFY@ $@ $@.sparse
 	mv $@.sparse $@
 
 %.tar.xz: %.raw
-	tar -cJS -C $$(dirname $<) -f $@ $$(basename $<)
+	XZ_OPT=-8e tar -cJS -C $$(dirname $<) -f $@ $$(basename $<)
 
 install: build/image/eucalyptus-service-image.tar.xz install-py
 	install -D -m 0644 $< $(DESTDIR)$(imagedir)/@PACKAGE_TARNAME@-@PACKAGE_VERSION@.tar.xz

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([eucalyptus-service-image], [4])
+AC_INIT([eucalyptus-service-image], [3])
 
 INSTALL_TREE=http://linux.mirrors.es.net/centos/7/os/x86_64/
 BASE_MIRROR=${INSTALL_TREE}

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([eucalyptus-service-image], [3])
+AC_INIT([eucalyptus-service-image], [3.32])
 
 INSTALL_TREE=http://linux.mirrors.es.net/centos/7/os/x86_64/
 BASE_MIRROR=${INSTALL_TREE}

--- a/eucalyptus-service-image.ks.in
+++ b/eucalyptus-service-image.ks.in
@@ -25,66 +25,44 @@ repo --name eucalyptus --baseurl=@EUCALYPTUS_MIRROR@
 # Add all the packages after the base packages
 %packages --excludedocs --instLangs=en
 @core
+
 audit
 bash
 chkconfig
+cloud-init
 coreutils
+createrepo
 curl
 e2fsprogs
 ec2-net-utils
+epel-release
+ntp
+ntpdate
 openssh-server
 passwd
 policycoreutils
 rootfiles
 sudo
 system-config-firewall-base
-ntp
-ntpdate
-createrepo
 yum-utils
 
-epel-release
-cloud-init
-eucalyptus-service-image-release
-
--plymouth
--plymouth-system-theme
--efibootmgr
+-*firmware
 -acl
--atmel-firmware
 -b43-openfwwf
 -cyrus-sasl
+-efibootmgr
+-mysql-libs
+-plymouth
+-plymouth-system-theme
 -postfix
 -sysstat
--xorg-x11-drv-ati-firmware
--ipw2100-firmware
--ipw2200-firmware
--ivtv-firmware
--iwl1000-firmware
--iwl3945-firmware
--iwl4965-firmware
--iwl5000-firmware
--iwl5150-firmware
--iwl6000-firmware
--iwl6050-firmware
--libertas-usb8388-firmware
--rt61pci-firmware
--rt73usb-firmware
--mysql-libs
--zd1211-firmware
--ql2100-firmware
--ql2200-firmware
--ql23xx-firmware
--ql2400-firmware
--ql2500-firmware
--aic94xx-firmware
--iwl6000g2a-firmware
--iwl100-firmware
--bfa-firmware
 %end
 
 %post --erroronfail --log=/root/kickstart-post.log
 set -x
+
+# packages cleanup
+yum -y erase linux-firmware
 
 # Setup console
 cat > /etc/init/ttyS0.conf <<EOF
@@ -156,6 +134,19 @@ EOF
 yumdownloader --resolve -c /tmp/yum-tmp.conf --destdir /var/lib/eucalyptus-service-image/packages eucalyptus-imaging-worker load-balancer-servo euca2ools
 createrepo /var/lib/eucalyptus-service-image/packages
 rm /tmp/yum-tmp.conf
+
+# Configure service packages repository
+cat > /etc/yum.repos.d/eucalyptus-service-image.repo << EOF
+[eucalyptus-service-image]
+name=Eucalyptus Service Image Packages - $basearch
+baseurl=file:///var/lib/eucalyptus-service-image/packages
+enabled=1
+gpgcheck=0
+skip_if_unavailable=1
+EOF
+
+yum clean all
+
 %end
 
 #vim: set syntax=kickstart:

--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -1,5 +1,5 @@
 Name:           eucalyptus-service-image
-Version:        3
+Version:        3.32
 Release:        0%{?dist}
 Summary:        Eucalyptus Service Image
 
@@ -25,6 +25,8 @@ Obsoletes:      eucalyptus-load-balancer-image < 1.2
 Provides:       eucalyptus-imaging-worker-image
 Provides:       eucalyptus-load-balancer-image
 
+# Use fast compression (image already compressed)
+%global _binary_payload w1.gzdio
 
 %description
 This package contains a machine image for use in Eucalyptus to

--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -1,5 +1,5 @@
 Name:           eucalyptus-service-image
-Version:        4
+Version:        3
 Release:        0%{?dist}
 Summary:        Eucalyptus Service Image
 
@@ -57,9 +57,6 @@ make install DESTDIR=$RPM_BUILD_ROOT
 
 
 %changelog
-* Tue Nov  8 2016 Garrett Holmstrom <gholms@hpe.com> - 4
-- Version bump (4)
-
 * Tue Nov  8 2016 Garrett Holmstrom <gholms@hpe.com> - 3
 - Version bump (3)
 


### PR DESCRIPTION
The service image version is modified to 3.32.

There are minor build changes to allow use from a docker image.