### PR TITLE
Service image cloud-user user

### DIFF
--- a/eucalyptus-service-image.ks.in
+++ b/eucalyptus-service-image.ks.in
@@ -74,13 +74,10 @@ exec /sbin/mingetty /dev/ttyS0
 EOF
 
 # Configure sudo
-sed -i '/requiretty/s/^/#/' /etc/sudoers
 sed -i '/!visiblepw/s/^/#/' /etc/sudoers
-echo "cloud-user ALL = NOPASSWD: ALL" >> /etc/sudoers
 
 # Configure cloud-init
-sed -i 's/name: fedora/name: cloud-user/' /etc/cloud/cloud.cfg
-sed -i 's/gecos: Fedora Cloud User/gecos: Cloud User/' /etc/cloud/cloud.cfg
+sed -i 's/name: centos/name: cloud-user/' /etc/cloud/cloud.cfg
 
 # Configure networking
 echo "NOZEROCONF=yes" >> /etc/sysconfig/network
@@ -88,6 +85,7 @@ echo "NETWORKING=yes" >> /etc/sysconfig/network
 
 # Configure sshd
 sed -i 's/PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/' /etc/ssh/sshd_config
 cat >> /etc/ssh/sshd_config <<EOF
 UseDNS no
 PermitRootLogin without-password


### PR DESCRIPTION
The service image is built using the latest centos 7. This means we are now on centos 7.4 instead of the centos 7.3 used for the last service image.

Listing the available cloud-init packages from the old image, we see:

```
Installed Packages
cloud-init.x86_64        0.7.5-6.el7                   @epel
Available Packages
cloud-init.x86_64        0.7.9-9.el7.centos.2          base 
```

so cloud-init is a more recent version and is now included in the "base" repository.

This pull request updates the kickstart to set the user correctly for the current version of cloud init.

This pull request is based on the branch for the previous pull request so I think will be more easily reviewed once that is merged.