### PR TITLE
Version bumped, now uses eucalyptus version (4.4)

### DIFF
--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -1,5 +1,5 @@
 Name:           eucalyptus-service-image
-Version:        3.32
+Version:        4.4
 Release:        0%{?dist}
 Summary:        Eucalyptus Service Image
 
@@ -59,6 +59,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Mar 14 2018 Steve Jones <steve.jones@appscale.com> - 4.4
+- Version bump (4.4), now versioned as per eucalyptus
+
 * Tue Nov  8 2016 Garrett Holmstrom <gholms@hpe.com> - 3
 - Version bump (3)
 


### PR DESCRIPTION
Version bumped as we will have a load balancer fix in the release. Switched versioning scheme so it is similar to eucalyptus-java-deps.