### PR TITLE
Install java package in image for faster elb start

### DIFF
--- a/eucalyptus-service-image.ks.in
+++ b/eucalyptus-service-image.ks.in
@@ -36,6 +36,7 @@ curl
 e2fsprogs
 ec2-net-utils
 epel-release
+java-1.8.0-openjdk
 ntp
 ntpdate
 openssh-server


### PR DESCRIPTION
Installing java when building the image avoids installing the package every time an elb starts up.

```
[   19.949750] cloud-init[976]: Cloud-init v. 0.7.9 running 'modules:final' at Wed, 02 May 2018 16:59:15 +0000. Up 19.87 seconds.
[   20.224719] cloud-init[976]: Loaded plugins: fastestmirror
[   20.381048] cloud-init[976]: Determining fastest mirrors
[   20.406101] cloud-init[976]: Resolving Dependencies
[   20.409658] cloud-init[976]: --> Running transaction check
[   20.413269] cloud-init[976]: ---> Package load-balancer-servo.noarch 0:1.4.2-0.14.elb.listenup.as.el7 will be installed
[   20.466322] cloud-init[976]: --> Processing Dependency: haproxy >= 1.5 for package: load-balancer-servo-1.4.2-0.14.elb.listenup.as.el7.noarch
...
[   22.568384] cloud-init[976]: --> Finished Dependency Resolution
[   22.706897] cloud-init[976]: Dependencies Resolved
[   22.728276] cloud-init[976]: ================================================================================
[   22.730889] cloud-init[976]: Package                 Arch   Version          Repository                Size
[   22.733495] cloud-init[976]: ================================================================================
[   22.735916] cloud-init[976]: Installing:
[   22.737569] cloud-init[976]: load-balancer-servo     noarch 1.4.2-0.14.elb.listenup.as.el7
[   22.739835] cloud-init[976]: eucalyptus-service-image  83 k
[   22.741535] cloud-init[976]: Installing for dependencies:
[   22.743135] cloud-init[976]: alsa-lib                    x86_64 1.1.3-3.el7                    eucalyptus-service-image 421 k
[   22.745558] cloud-init[976]: copy-jdk-configs            noarch 2.2-5.el7_4                    eucalyptus-service-image  19 k
[   22.747755] cloud-init[976]: eucalyptus-common-java-libs x86_64 4.4.3-0.14.elb.listenup.as.el7 eucalyptus-service-image  13 M
[   22.760926] cloud-init[976]: eucalyptus-java-deps        noarch 4.4-1.14.elb.listenup.as.el7   eucalyptus-service-image  59 M
[   22.765219] cloud-init[976]: eucalyptus-selinux          noarch 0.2.3-1.14.elb.listenup.as.el7 eucalyptus-service-image  23 k
[   22.776764] cloud-init[976]: fontconfig                  x86_64 2.10.95-11.el7                 eucalyptus-service-image 229 k
[   22.779142] cloud-init[976]: fontpackages-filesystem     noarch 1.44-8.el7                     eucalyptus-service-image 9.9 k
[   22.781469] cloud-init[976]: giflib                      x86_64 4.1.6-9.el7                    eucalyptus-service-image  40 k
[   22.783765] cloud-init[976]: haproxy                     x86_64 1.5.18-6.el7                   eucalyptus-service-image 834 k
[   22.787194] cloud-init[976]: java-1.8.0-openjdk          x86_64 1:1.8.0.161-0.b14.el7_4        eucalyptus-service-image 243 k
[   22.791629] cloud-init[976]: java-1.8.0-openjdk-headless x86_64 1:1.8.0.161-0.b14.el7_4        eucalyptus-service-image  32 M
[   22.796696] cloud-init[976]: javapackages-tools      noarch 3.4.1-11.el7     eucalyptus-service-image  73 k
[   22.811345] cloud-init[976]: jemalloc                x86_64 3.6.0-1.el7      eucalyptus-service-image 105 k
[   22.813644] cloud-init[976]: libICE                  x86_64 1.0.9-9.el7      eucalyptus-service-image  66 k
[   22.815917] cloud-init[976]: libSM                   x86_64 1.2.2-2.el7      eucalyptus-service-image  39 k
[   22.818379] cloud-init[976]: libX11                  x86_64 1.6.5-1.el7      eucalyptus-service-image 606 k
[   22.821072] cloud-init[976]: libX11-common           noarch 1.6.5-1.el7      eucalyptus-service-image 164 k
[   22.823649] cloud-init[976]: libXau                  x86_64 1.0.8-2.1.el7    eucalyptus-service-image  29 k
[   22.825850] cloud-init[976]: libXcomposite           x86_64 0.4.4-4.1.el7    eucalyptus-service-image  22 k
[   22.828164] cloud-init[976]: libXext                 x86_64 1.3.3-3.el7      eucalyptus-service-image  39 k
[   22.843755] cloud-init[976]: libXfont                x86_64 1.5.2-1.el7      eucalyptus-service-image 152 k
[   22.846544] cloud-init[976]: libXi                   x86_64 1.7.9-1.el7      eucalyptus-service-image  40 k
[   22.848843] cloud-init[976]: libXrender              x86_64 0.9.10-1.el7     eucalyptus-service-image  26 k
[   22.851137] cloud-init[976]: libXtst                 x86_64 1.2.3-1.el7      eucalyptus-service-image  20 k
[   22.876102] cloud-init[976]: libfontenc              x86_64 1.1.3-3.el7      eucalyptus-service-image  31 k
[   22.878966] cloud-init[976]: libjpeg-turbo           x86_64 1.2.90-5.el7     eucalyptus-service-image 134 k
[   22.881351] cloud-init[976]: libpng                  x86_64 2:1.5.13-7.el7_2 eucalyptus-service-image 213 k
[   22.883620] cloud-init[976]: libxcb                  x86_64 1.12-1.el7       eucalyptus-service-image 211 k
[   22.896683] cloud-init[976]: libxslt                 x86_64 1.1.28-5.el7     eucalyptus-service-image 242 k
[   22.899574] cloud-init[976]: lksctp-tools            x86_64 1.0.17-2.el7     eucalyptus-service-image  88 k
[   22.901862] cloud-init[976]: lyx-fonts               noarch 2.2.3-1.el7      eucalyptus-service-image 159 k
[   22.904234] cloud-init[976]: m2crypto                x86_64 0.21.1-17.el7    eucalyptus-service-image 429 k
[   22.906815] cloud-init[976]: python-httplib2         noarch 0.9.2-1.el7      eucalyptus-service-image 115 k
[   22.909240] cloud-init[976]: python-javapackages     noarch 3.4.1-11.el7     eucalyptus-service-image  31 k
[   22.911578] cloud-init[976]: python-lxml             x86_64 3.2.1-4.el7      eucalyptus-service-image 758 k
[   22.913857] cloud-init[976]: python-netaddr          noarch 0.7.5-7.el7      eucalyptus-service-image 983 k
[   22.916204] cloud-init[976]: python-redis            noarch 2.10.3-1.el7     eucalyptus-service-image  94 k
[   22.919189] cloud-init[976]: python2-boto            noarch 2.45.0-3.el7     eucalyptus-service-image 1.7 M
[   22.921603] cloud-init[976]: python2-pyasn1          noarch 0.1.9-7.el7      eucalyptus-service-image 100 k
[   22.924052] cloud-init[976]: python2-rsa             noarch 3.4.1-1.el7      eucalyptus-service-image  67 k
[   22.926487] cloud-init[976]: redis                   x86_64 3.2.10-2.el7     eucalyptus-service-image 545 k
[   22.950980] cloud-init[976]: ttmkfdir                x86_64 3.0.9-42.el7     eucalyptus-service-image  48 k
[   22.955998] cloud-init[976]: tzdata-java             noarch 2018d-1.el7      eucalyptus-service-image 184 k
[   22.971932] cloud-init[976]: xorg-x11-font-utils     x86_64 1:7.5-20.el7     eucalyptus-service-image  87 k
[   22.976975] cloud-init[976]: xorg-x11-fonts-Type1    noarch 7.5-9.el7        eucalyptus-service-image 521 k
[   22.992940] cloud-init[976]: Transaction Summary
[   22.996457] cloud-init[976]: ================================================================================
[   23.001571] cloud-init[976]: Install  1 Package (+45 Dependent packages)
[   23.017501] cloud-init[976]: Total download size: 113 M
[   23.021127] cloud-init[976]: Installed size: 221 M
[   23.024623] cloud-init[976]: Downloading packages:
[   23.897070] cloud-init[976]: --------------------------------------------------------------------------------
[   23.899241] cloud-init[976]: Total                                              100 MB/s | 113 MB  00:01
[   23.923079] cloud-init[976]: Running transaction check
[   24.242113] cloud-init[976]: Running transaction test
[   24.445113] cloud-init[976]: Transaction test succeeded
[   24.447989] cloud-init[976]: Running transaction
[   26.107453] cloud-init[976]: Installing : libfontenc-1.1.3-3.el7.x86_64                               1/46
...
[   90.887131] cloud-init[976]: Installing : load-balancer-servo-1.4.2-0.14.elb.listenup.as.el7.noarc   46/46
[   91.226176] cloud-init[976]: Verifying  : libXext-1.3.3-3.el7.x86_64                                  1/46
...
[  106.608061] cloud-init[976]: Verifying  : 1:xorg-x11-font-utils-7.5-20.el7.x86_64                    46/46
[  106.612393] cloud-init[976]: Installed:
[  106.614670] cloud-init[976]: load-balancer-servo.noarch 0:1.4.2-0.14.elb.listenup.as.el7
[  106.618705] cloud-init[976]: Dependency Installed:
[  106.621364] cloud-init[976]: alsa-lib.x86_64 0:1.1.3-3.el7
...
[  106.761467] cloud-init[976]: xorg-x11-fonts-Type1.noarch 0:7.5-9.el7
[  106.765447] cloud-init[976]: Complete!

```

with the package already installed:

```
[   20.133677] cloud-init[979]: Cloud-init v. 0.7.9 running 'modules:final' at Wed, 02 May 2018 21:07:39 +0000. Up 19.96 seconds.
[   20.670103] cloud-init[979]: Loaded plugins: fastestmirror
[   20.991646] cloud-init[979]: Determining fastest mirrors
[   21.028100] cloud-init[979]: Resolving Dependencies
[   21.031797] cloud-init[979]: --> Running transaction check
[   21.035583] cloud-init[979]: ---> Package load-balancer-servo.noarch 0:1.4.2-0.18.packages.as.el7 will be installed
[   21.094989] cloud-init[979]: --> Processing Dependency: haproxy >= 1.5 for package: load-balancer-servo-1.4.2-0.18.packages.as.el7.noarch
...
[   22.824256] cloud-init[979]: --> Finished Dependency Resolution
[   22.901753] cloud-init[979]: Dependencies Resolved
[   22.911715] cloud-init[979]: ================================================================================
[   22.914055] cloud-init[979]: Package                 Arch   Version          Repository                Size
[   22.916409] cloud-init[979]: ================================================================================
[   22.918736] cloud-init[979]: Installing:
[   22.920337] cloud-init[979]: load-balancer-servo     noarch 1.4.2-0.18.packages.as.el7
[   22.925597] cloud-init[979]: eucalyptus-service-image  83 k
[   22.927357] cloud-init[979]: Installing for dependencies:
[   22.929050] cloud-init[979]: eucalyptus-common-java-libs
[   22.930720] cloud-init[979]: x86_64 4.4.3-0.18.packages.as.el7
[   22.932463] cloud-init[979]: eucalyptus-service-image  13 M
[   22.934192] cloud-init[979]: eucalyptus-java-deps    noarch 4.4-1.18.packages.as.el7
[   22.936770] cloud-init[979]: eucalyptus-service-image  59 M
[   22.938448] cloud-init[979]: eucalyptus-selinux      noarch 0.2.3-1.18.packages.as.el7
[   22.940613] cloud-init[979]: eucalyptus-service-image  23 k
[   22.942237] cloud-init[979]: haproxy                 x86_64 1.5.18-6.el7     eucalyptus-service-image 834 k
[   22.944638] cloud-init[979]: jemalloc                x86_64 3.6.0-1.el7      eucalyptus-service-image 105 k
[   22.946828] cloud-init[979]: m2crypto                x86_64 0.21.1-17.el7    eucalyptus-service-image 429 k
[   22.964504] cloud-init[979]: python-httplib2         noarch 0.9.2-1.el7      eucalyptus-service-image 115 k
[   22.966802] cloud-init[979]: python-netaddr          noarch 0.7.5-7.el7      eucalyptus-service-image 983 k
[   22.969065] cloud-init[979]: python-redis            noarch 2.10.3-1.el7     eucalyptus-service-image  94 k
[   22.971331] cloud-init[979]: python2-boto            noarch 2.45.0-3.el7     eucalyptus-service-image 1.7 M
[   22.974110] cloud-init[979]: python2-pyasn1          noarch 0.1.9-7.el7      eucalyptus-service-image 100 k
[   22.976424] cloud-init[979]: python2-rsa             noarch 3.4.1-1.el7      eucalyptus-service-image  67 k
[   22.978703] cloud-init[979]: redis                   x86_64 3.2.10-2.el7     eucalyptus-service-image 545 k
[   22.980936] cloud-init[979]: Transaction Summary
[   22.982483] cloud-init[979]: ================================================================================
[   22.998122] cloud-init[979]: Install  1 Package (+13 Dependent packages)
[   23.000137] cloud-init[979]: Total download size: 77 M
[   23.001946] cloud-init[979]: Installed size: 104 M
[   23.003679] cloud-init[979]: Downloading packages:
[   23.637119] cloud-init[979]: --------------------------------------------------------------------------------
[   23.641561] cloud-init[979]: Total                                              108 MB/s |  77 MB  00:00
[   23.668095] cloud-init[979]: Running transaction check
[   23.901122] cloud-init[979]: Running transaction test
[   24.049124] cloud-init[979]: Transaction test succeeded
[   24.052078] cloud-init[979]: Running transaction
[   33.814571] cloud-init[979]: Installing : eucalyptus-java-deps-4.4-1.18.packages.as.el7.noarch        1/14
...
[   54.371603] cloud-init[979]: Installing : load-balancer-servo-1.4.2-0.18.packages.as.el7.noarch      14/14
[   54.761529] cloud-init[979]: Verifying  : m2crypto-0.21.1-17.el7.x86_64                               1/14
...
[   60.179117] cloud-init[979]: Verifying  : eucalyptus-java-deps-4.4-1.18.packages.as.el7.noarch       14/14
[   60.183588] cloud-init[979]: Installed:
[   60.185924] cloud-init[979]: load-balancer-servo.noarch 0:1.4.2-0.18.packages.as.el7
[   60.190086] cloud-init[979]: Dependency Installed:
[   60.192800] cloud-init[979]: eucalyptus-common-java-libs.x86_64 0:4.4.3-0.18.packages.as.el7
...
[   60.234342] cloud-init[979]: redis.x86_64 0:3.2.10-2.el7
[   60.237971] cloud-init[979]: Complete!
```

The difference would likely be smaller on a production environment.