### PR TITLE
esi commands should use euca2ools configured region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+*.iml
 *.ks
 config.status
 config.log
 configure
 Makefile
+.idea/
 autom4te.cache/
 build/
 dist/

--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -54,14 +54,13 @@ class ServiceImageManager(EsiBase):
         self._ec2 = boto.connect_ec2_endpoint(self.get_env_var('EC2_URL'))
         self._populate_images()
 
-
     def _populate_images(self):
         self.images = {}
         for image in self._ec2.get_all_images():
             name = image.name
             if self.IMAGE_RE.search(name):
                 version = self._get_image_version(image)
-                if not version in self.images:
+                if version not in self.images:
                     self.images[version] = []
                 self.images[version].append(ImageInfo(image.id, image.location))
 
@@ -83,10 +82,10 @@ class ServiceImageManager(EsiBase):
 
             if should_remove:
                 for image in image_set:
-                    self._run_command(['/usr/bin/euca-deregister', image.id, '--region', self.region], True)
+                    self._run_command(['/usr/bin/euca-deregister', image.id] + self.region_args, True)
                     (bucket, prefix) = self._split_location(image.location)
                     self._run_command(['/usr/bin/euca-delete-bundle', '-b', bucket,
-                                       '-p', prefix, '--region', self.region], True)
+                                       '-p', prefix] + self.region_args, True)
                     removed.append(image.id)
         return removed
 
@@ -152,18 +151,17 @@ class ServiceImageManager(EsiBase):
             print "Please make sure that you have your env configured: EUCALYPTUS_CERT or EUCA_BOOTSTRAP_URL" \
                   " are not set. Please configure at least one of them"
             sys.exit(1)
-        ### Decompress image
+        # Decompress image
         print "Decompressing tarball: " + tarball
         decompress_stdout, decompress_stderr = self._run_command(['/bin/tar', 'vxJf', tarball])
-        ### Bundle and upload image
+        # Bundle and upload image
         image_file = decompress_stdout.strip()
         print "Installing image from {0}".format(image_file)
         print "Bundling, uploading and registering image to bucket: " + image_name
         cmd = ['/usr/bin/euca-install-image',
                '-b', image_name, '-i', image_file,
                '-r', 'x86_64', '-n', image_name, '--virt', 'hvm',
-               '--region', self.region,
-               '--user', self.get_env_var('EC2_USER_ID')]
+               '--user', self.get_env_var('EC2_USER_ID')] + self.region_args
         if self.get_env_var('EUCA_BOOTSTRAP_URL') is None:
             cmd.append('--ec2cert')
             cmd.append(self.get_env_var('EUCALYPTUS_CERT'))


### PR DESCRIPTION
The region for esi commands no longer defaults to localhost, allowing the euca2ools configured default region to be picked up.

This does change the behavior when the region is not passed in, configured in euca2ools, or set in the environment, but is now consistent with other tools that also fail rather than using localhost.

This pull request fixes Corymbia/eucalyptus#53