### PR TITLE
Version now 4.4-1, update rpm url metadata

### DIFF
--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -1,6 +1,6 @@
 Name:           eucalyptus-service-image
 Version:        4.4
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        Eucalyptus Service Image
 
 Group:          Applications/System

--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -6,7 +6,7 @@ Summary:        Eucalyptus Service Image
 Group:          Applications/System
 # License needs to be the *distro's* license (Fedora is GPLv2, for instance)
 License:        GPLv2
-URL:            http://www.eucalyptus.com/
+URL:            https://eucalyptus.cloud/
 BuildArch:      noarch
 
 Source0:        %{name}-%{version}.tar.xz


### PR DESCRIPTION
Bump version (release) to 4.4-1 and update rpm url metadata for eucalyptus.cloud