### PR TITLE
Bump version not release so image gets upgraded (4.4.101)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([eucalyptus-service-image], [4.4])
+AC_INIT([eucalyptus-service-image], [4.4.101])
 
 INSTALL_TREE=http://linux.mirrors.es.net/centos/7/os/x86_64/
 BASE_MIRROR=${INSTALL_TREE}

--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -1,6 +1,6 @@
 Name:           eucalyptus-service-image
-Version:        4.4
-Release:        1%{?dist}
+Version:        4.4.101
+Release:        0%{?dist}
 Summary:        Eucalyptus Service Image
 
 Group:          Applications/System


### PR DESCRIPTION
This pull request bumps the version for the service image. The release had been bumped due to there being changes in 4.4.4 but changing only the release is not sufficient for:

```
# esi-install-image --install-default
```

to install the updated image.

The version 4.4 was picked for the service image to make it more obvious that the service image should be used with that eucalyptus version. Since we now have to bump the version `.101` is added to try and make a distinction between the service image version e.g. `4.4.101` and the eucalyptus version `4.4.4`