### PR TITLE
Update packaging with tar and xz dependencies

### DIFF
--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -1,6 +1,6 @@
 Name:           eucalyptus-service-image
 Version:        4.4.101
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        Eucalyptus Service Image
 
 Group:          Applications/System
@@ -19,6 +19,8 @@ BuildRequires:  python-devel
 Requires:       euca2ools >= 3.3
 Requires:       eucalyptus-admin-tools >= 4.2
 Requires:       python-prettytable
+Requires:       tar
+Requires:       xz
 
 Obsoletes:      eucalyptus-imaging-worker-image < 1.1
 Obsoletes:      eucalyptus-load-balancer-image < 1.2
@@ -59,6 +61,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Nov 14 2018 Steve Jones <steve.jones@appscale.com>
+- Add dependencies for tar and xz used for default image install
+
 * Wed Mar 14 2018 Steve Jones <steve.jones@appscale.com> - 4.4
 - Version bump (4.4), now versioned as per eucalyptus
 


### PR DESCRIPTION
`esi-install-image` uses `tar` and `xz`, so should declare these as dependencies.

https://github.com/Corymbia/eucalyptus-service-image/blob/master/bin/esi-install-image#L156