### PR TITLE
Fix ambiguous python shebangs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -49,6 +49,7 @@ install: build/image/eucalyptus-service-image.tar.xz install-py
 ifdef DESTDIR
 install-py: build-py
 	@PYTHON@ setup.py install -O1 --skip-build --root $(DESTDIR)
+	@sed --in-place '1s/python$$/python2/' $(DESTDIR)/usr/bin/esi-*
 else
 install-py: build-py
 	@PYTHON@ setup.py install -O1 --skip-build


### PR DESCRIPTION
Fix ambiguous python shebangs as these can otherwise cause build failures.

Example packaging guidelines covering python 2 use:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_multiple_python_runtimes

Build:  ocd/job/eucalyptus-internal-5-build-random-rpms/57/
QA run: ocd/job/eucalyptus-5-qa-suite/55/