### PR TITLE
Service image support for two step builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,8 @@ prefix = @prefix@
 datarootdir = @datarootdir@
 datadir = @datadir@
 imagedir = @datadir@/eucalyptus/service-images
+baseimage = @BASEIMAGE@
+usebaseimage = @USEBASEIMAGE@
 
 define destroyvm
 virsh undefine $<; virsh destroy $<; true
@@ -23,6 +25,10 @@ build-py: setup.py $(wildcard bin/*) $(wildcard esitoolsupport/*)
 
 build/image/eucalyptus-service-image.raw: eucalyptus-service-image.ks
 	mkdir -m 777 -p build/image
+ifneq ($(strip $(usebaseimage)),)
+	mv $(usebaseimage) $@
+	touch $@
+else
 	$(destroyvm)
 	@PYTHON@ -c 'import pty, sys; pty.spawn(sys.argv[1:])' \
 		@VIRT_INSTALL@ --name $< \
@@ -39,8 +45,14 @@ build/image/eucalyptus-service-image.raw: eucalyptus-service-image.ks
 	@VIRT_SYSPREP@ -a $@
 	@VIRT_SPARSIFY@ $@ $@.sparse
 	mv $@.sparse $@
+endif
 
 %.tar.xz: %.raw
+ifeq ($(strip $(baseimage)),)
+	/bin/bash eucalyptus-service-image-post.sh $<
+	@VIRT_SPARSIFY@ $< $<.sparse
+	mv $<.sparse $<
+endif
 	XZ_OPT=-8e tar -cJS -C $$(dirname $<) -f $@ $$(basename $<)
 
 install: build/image/eucalyptus-service-image.tar.xz install-py

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ UPDATES_MIRROR=http://linux.mirrors.es.net/centos/7/updates/x86_64/
 EPEL_MIRROR=http://linux.mirrors.es.net/epel/7/x86_64/
 EUCALYPTUS_MIRROR=http://downloads.eucalyptus.com/software/eucalyptus/4.4/rhel/7/x86_64/
 EUCA2OOLS_MIRROR=http://downloads.eucalyptus.com/software/euca2ools/3.3/rhel/7/x86_64/
+BASEIMAGE=
+USEBASEIMAGE=
 
 AC_ARG_WITH(install-tree,
     [  --with-install-tree=<dir>       the location of the install tree],
@@ -25,6 +27,12 @@ AC_ARG_WITH(eucalyptus-mirror,
 AC_ARG_WITH(euca2ools-mirror,
     [  --with-euca2ools-mirror=<dir>   the location of the euca2ools mirror],
     [EUCA2OOLS_MIRROR="${withval}"])
+AC_ARG_WITH(base-image-file,
+    [  --with-base-image-file          the location of an existing base image],
+    [USEBASEIMAGE="${withval}"])
+AC_ARG_ENABLE(base-image-only,
+    [  --enable-base-image-only        build a base image],
+    [BASEIMAGE="true"])
 
 AC_PATH_PROG(PYTHON, python)
 AC_PATH_PROG(VIRSH, virsh)
@@ -48,6 +56,7 @@ fi
 AC_CONFIG_FILES([
     Makefile
     eucalyptus-service-image.ks
+    eucalyptus-service-image-post.sh
 ])
 AC_SUBST(INSTALL_TREE)
 AC_SUBST(BASE_MIRROR)
@@ -59,4 +68,6 @@ AC_SUBST(VIRSH)
 AC_SUBST(VIRT_INSTALL)
 AC_SUBST(VIRT_SYSPREP)
 AC_SUBST(VIRT_SPARSIFY)
+AC_SUBST(BASEIMAGE)
+AC_SUBST(USEBASEIMAGE)
 AC_OUTPUT

--- a/eucalyptus-service-image-post.sh.in
+++ b/eucalyptus-service-image-post.sh.in
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Post base image creation steps
+#
+# The base image should not have any eucalyptus build specific content
+# the post step will customize the image.
+#
+set -euxo pipefail
+
+# Config
+IMAGE_PATH="${1:-eucalyptus-service-image.raw}"
+IMAGE_MOUNT="${IMAGE_MOUNT:-/tmp/image}"
+REPO_BASE="${REPO_BASE:-@BASE_MIRROR@}"
+REPO_UPDATES="${REPO_UPDATES:-@UPDATES_MIRROR@}"
+REPO_EPEL="${REPO_EPEL:-@EPEL_MIRROR@}"
+REPO_EUCALYPTUS="${REPO_EUCALYPTUS:-@EUCALYPTUS_MIRROR@}"
+REPO_EUCA2OOLS="${REPO_EUCA2OOLS:-@EUCA2OOLS_MIRROR@}"
+
+# Image setup
+LOOP_DEVICE=$(losetup --find)
+MAPPER_P1_DEVICE="/dev/mapper/${LOOP_DEVICE##/dev/}p1"
+
+image_post_cleanup ()
+{
+  umount "${IMAGE_MOUNT}/tmp"             || true
+  umount "${IMAGE_MOUNT}/dev"             || true
+  umount "${IMAGE_MOUNT}/etc/resolv.conf" || true
+  umount "${IMAGE_MOUNT}"                 || true
+  kpartx -d "${LOOP_DEVICE}"              || true
+  losetup -d "${LOOP_DEVICE}"             || true
+}
+trap image_post_cleanup EXIT
+
+[ -e "${LOOP_DEVICE}" ] || for N in {0..7}; do mknod /dev/loop$N -m0660 b 7 $N; done
+losetup "${LOOP_DEVICE}" "${IMAGE_PATH}"
+kpartx -a "${LOOP_DEVICE}"
+[ -e "${IMAGE_MOUNT}" ] || mkdir -p "${IMAGE_MOUNT}"
+mount "${MAPPER_P1_DEVICE}" "${IMAGE_MOUNT}"
+mount -o bind "/dev" "${IMAGE_MOUNT}/dev"
+mount -o ro,bind "/etc/resolv.conf" "${IMAGE_MOUNT}/etc/resolv.conf"
+mount -t tmpfs -o size=512m tmpfs "${IMAGE_MOUNT}/tmp"
+
+# Download service packages for installation at runtime
+cat >> "${IMAGE_MOUNT}/tmp/yum-tmp.conf" <<EOF
+[main]
+keepcache=0
+exactarch=1
+obsoletes=1
+plugins=0
+distroverpkg=centos-release
+debuglevel=2
+logfile=/dev/null
+reposdir=/dev/null
+
+[base]
+name=base
+baseurl=${REPO_BASE}
+enabled=1
+
+[updates]
+name=updates
+baseurl=${REPO_UPDATES}
+enabled=1
+
+[epel]
+name=epel
+baseurl=${REPO_EPEL}
+enabled=1
+
+[eucalyptus]
+name=eucalyptus
+baseurl=${REPO_EUCALYPTUS}
+enabled=1
+
+[euca2ools]
+name=euca2ools
+baseurl=${REPO_EUCA2OOLS}
+enabled=1
+EOF
+
+chroot "${IMAGE_MOUNT}" yumdownloader --resolve --config=/tmp/yum-tmp.conf --destdir=/var/lib/eucalyptus-service-image/packages eucalyptus-imaging-worker load-balancer-servo euca2ools
+chroot "${IMAGE_MOUNT}" createrepo /var/lib/eucalyptus-service-image/packages
+
+# Configure service packages repository
+cat > "${IMAGE_MOUNT}/etc/yum.repos.d/eucalyptus-service-image.repo" << "EOF"
+[eucalyptus-service-image]
+name=Eucalyptus Service Image Packages - $basearch
+baseurl=file:///var/lib/eucalyptus-service-image/packages
+enabled=1
+gpgcheck=0
+skip_if_unavailable=1
+EOF
+
+rm -rf "${IMAGE_MOUNT}/var/lib/yum/uuid"
+rm -rf "${IMAGE_MOUNT}/var/cache/yum/"*
+

--- a/eucalyptus-service-image.ks.in
+++ b/eucalyptus-service-image.ks.in
@@ -122,58 +122,6 @@ UseDNS no
 PermitRootLogin without-password
 EOF
 
-# Download service packages for installation at runtime
-cat >> /tmp/yum-tmp.conf <<EOF
-[main]
-keepcache=0
-exactarch=1
-obsoletes=1
-plugins=0
-distroverpkg=centos-release
-debuglevel=2
-logfile=/dev/null
-reposdir=/dev/null
-
-[base]
-name=base
-baseurl=@BASE_MIRROR@
-enabled=1
-
-[updates]
-name=updates
-baseurl=@UPDATES_MIRROR@
-enabled=1
-
-[epel]
-name=epel
-baseurl=@EPEL_MIRROR@
-enabled=1
-
-[eucalyptus]
-name=eucalyptus
-baseurl=@EUCALYPTUS_MIRROR@
-enabled=1
-
-[euca2ools]
-name=euca2ools
-baseurl=@EUCA2OOLS_MIRROR@
-enabled=1
-EOF
-
-yumdownloader --resolve -c /tmp/yum-tmp.conf --destdir /var/lib/eucalyptus-service-image/packages eucalyptus-imaging-worker load-balancer-servo euca2ools
-createrepo /var/lib/eucalyptus-service-image/packages
-rm /tmp/yum-tmp.conf
-
-# Configure service packages repository
-cat > /etc/yum.repos.d/eucalyptus-service-image.repo << EOF
-[eucalyptus-service-image]
-name=Eucalyptus Service Image Packages - $basearch
-baseurl=file:///var/lib/eucalyptus-service-image/packages
-enabled=1
-gpgcheck=0
-skip_if_unavailable=1
-EOF
-
 yum clean all
 
 %end


### PR DESCRIPTION
Service image build is updated to allow two distinct steps:

* base image build
* full build

The base image build can then be re-used as it does not contain build specific artifacts.

By default a single step build is performed.
