### PR TITLE
Service image should include cloud-utils-growpart package

### DIFF
--- a/eucalyptus-service-image.ks.in
+++ b/eucalyptus-service-image.ks.in
@@ -30,6 +30,7 @@ audit
 bash
 chkconfig
 cloud-init
+cloud-utils-growpart
 coreutils
 createrepo
 curl


### PR DESCRIPTION
The `cloud-utils-growpart` package is used by cloud init to increase the size of the root partition on firstboot.

Build: /job/eucalyptus-internal-5-build-random-rpms/222/
Stage: /job/eucalyptus-internal-5-stage-random/184/
Deploy: /job/eucalyptus-5-ansible-deploy/147/
Test: /job/eucalyptus-5-qa-suite/172/

Demo is that the service image is installed:

```
# rpm -q eucalyptus-service-image
eucalyptus-service-image-5.0.100-0.222.simgp.as.el7.noarch
```

and that it contains the package:

```
[root@euca-172-31-13-109 ~]# rpm -qi cloud-utils-growpart
Name        : cloud-utils-growpart
Version     : 0.29
Release     : 5.el7
Architecture: noarch
Install Date: Tue 25 Aug 2020 05:16:13 PM UTC
...
```